### PR TITLE
Make sure that an initial // in the URL does not hurt

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -478,6 +478,9 @@ class fakesock(object):
                     return
 
             # path might come with
+            if path.startswith('/'):
+                # Need to make sure that there is a scheme
+                path = 'zz://' + path
             s = urlsplit(path)
             POTENTIAL_HTTP_PORTS.add(int(s.port or 80))
             parts = list(map(utf8, data.split(b'\r\n\r\n', 1)))


### PR DESCRIPTION
The code uses urlsplit to try and parse the URL without a scheme. It therefore considers

//v1/foo

as host v1, path /foo with no scheme. Arg!

This fixes it.