### PR TITLE
Fix a missing encode that causes a crash

### DIFF
--- a/httpretty/__init__.py
+++ b/httpretty/__init__.py
@@ -25,7 +25,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import unicode_literals
 
-__version__ = version = '0.8.14'
+__version__ = version = '0.8.14+1'
 
 from .core import httpretty, httprettified, EmptyRequestHeaders
 from .errors import HTTPrettyError, UnmockedError

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -737,7 +737,7 @@ class Entry(BaseClass):
 
 
 def url_fix(s, charset='utf-8'):
-    scheme, netloc, path, querystring, fragment = urlsplit(s)
+    scheme, netloc, path, querystring, fragment = urlsplit(s.encode('utf-8'))
     path = quote(path, b'/%')
     querystring = quote_plus(querystring, b':&=')
     return urlunsplit((scheme, netloc, path, querystring, fragment))


### PR DESCRIPTION
This fixes a problem where the urllib expects that quote is passed a byte string and not a unicode string.