### PR TITLE
Make HTTPretty thread-safe

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -502,6 +502,8 @@ class fakesock(object):
             self.fd = FakeSockFile()
             self.fd.socket = self
             try:
+                if isinstance(data, memoryview):
+                    data = data.tobytes()
                 requestline, _ = data.split(b'\r\n', 1)
                 method, path, version = parse_requestline(
                     decode_utf8(requestline))

--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -1074,14 +1074,22 @@ class URIMatcher(object):
         if self.current_entries[method] != -1:
             self.current_entries[method] += 1
 
+        # Create a copy of the original entry to make it thread-safe
+        body = entry.callable_body if entry.body_is_callable else entry.body
+        new_entry = Entry(entry.method, entry.uri, body,
+                          status=entry.status,
+                          streaming=entry.streaming,
+                          adding_headers=entry.adding_headers,
+                          forcing_headers=entry.forcing_headers)
+
         # Attach more info to the entry
         # So the callback can be more clever about what to do
         # This does also fix the case where the callback
         # would be handed a compiled regex as uri instead of the
         # real uri
-        entry.info = info
-        entry.request = request
-        return entry
+        new_entry.info = info
+        new_entry.request = request
+        return new_entry
 
     def __hash__(self):
         return hash(text_type(self))

--- a/httpretty/version.py
+++ b/httpretty/version.py
@@ -1,1 +1,1 @@
-version = '0.9.6+bs1'
+version = '0.9.6+bs2'


### PR DESCRIPTION
Pull in a fix for HTTPretty not being thread-safe from other people. These PRs haven't been merged into the actual project because they cause one test to fail on TravisCI.

https://github.com/gabrielfalcao/HTTPretty/pull/333
https://github.com/gabrielfalcao/HTTPretty/pull/252